### PR TITLE
check if plugin is given in json file

### DIFF
--- a/download_plugins.py
+++ b/download_plugins.py
@@ -6,7 +6,14 @@ def get_dependencies(plugin):
     print "*****************************************"
     print plugin, "has these dependencies:"
 
-    for dependency in plugins_list['plugins'][plugin]['dependencies']:
+    try:
+        dependencies = plugins_list['plugins'][plugin]['dependencies']
+    except KeyError:
+        print "Unable to find dependencies for %s." % plugin
+        exit_code = 1
+        return None
+    
+    for dependency in dependencies:
         print "Processing dependency: " + dependency['name']
         
         if (dependency['name'] not in installed_plugins) and (not dependency['optional']):


### PR DESCRIPTION
this change came out of necessity due to the actions Jenkins took to hide their cas-plugin. A security hole was found in this plugin, so Jenkins removed the cas-plugin entry from it's [JSON file](https://updates.jenkins.io/current/update-center.actual.json). They also tried to hide cas-plugin.hpi, but I managed to download it by using a direct url to the version I wanted.

The pluginator was able to download cas-plugin.hpi but it couldn't find it's dependencies which threw a KeyError and exited the program.

This change allows the program to keep going but exit with a status of 1 if there was a problem. If a plugin isn't given in the [JSON file](https://updates.jenkins.io/current/update-center.actual.json), the culprate plugin is printed to STDOUT.